### PR TITLE
fixed missing ? in get request url string creation

### DIFF
--- a/score/jsapi/api.js.tpl
+++ b/score/jsapi/api.js.tpl
@@ -93,7 +93,7 @@ define("%s", ["lib/score/oop", "lib/score/js/excformat", "lib/bluebird"], functi
                     for (var i = 0; i < requests.length; i++) {
                         data.push('requests[]=' + encodeURIComponent(JSON.stringify(requests[i])));
                     }
-                    request.open('GET', self.url + data.join('&'));
+                    request.open('GET', self.url + '?' + data.join('&'));
                     request.send();
                 } else {
                     request.open(self.method, self.url);


### PR DESCRIPTION
all GET request fails cause of missing url parameter separator.
