### PR TITLE
Fix: Missing UMD dependency in queue.js

### DIFF
--- a/score/jsapi/js/queue.js
+++ b/score/jsapi/js/queue.js
@@ -40,7 +40,7 @@
         module.exports = factory(require('./endpoint'), require('./exception'));
     } else {
         // Browser globals (root is window)
-        root.score.jsapi.Queue = factory(root.score.jsapi.Exception);
+        root.score.jsapi.Queue = factory(root.score.jsapi.Endpoint, root.score.jsapi.Exception);
     }
 })(this, function(Endpoint, Exception) {
 


### PR DESCRIPTION
Browser globals was missing `Endpoint` as dependency